### PR TITLE
Fix typos and secret namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ contribution. See the [DCO](DCO) file for details.
 
 Anyone may comment on issues and submit reviews for pull requests. However, in
 order to be assigned an issue or pull request, you must be a member of the
-[open-cluster-management](https://github.com/stolostron) GitHub organization.
+[open-cluster-management](https://github.com/mbaldessari) GitHub organization.
 
 Repo maintainers can assign you an issue or pull request by leaving a
 `/assign <your Github ID>` comment on the issue or pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ contribution. See the [DCO](DCO) file for details.
 
 Anyone may comment on issues and submit reviews for pull requests. However, in
 order to be assigned an issue or pull request, you must be a member of the
-[open-cluster-management](https://github.com/open-cluster-management) GitHub organization.
+[open-cluster-management](https://github.com/stolostron) GitHub organization.
 
 Repo maintainers can assign you an issue or pull request by leaving a
 `/assign <your Github ID>` comment on the issue or pull request.

--- a/cloud-provider/README.md
+++ b/cloud-provider/README.md
@@ -3,7 +3,7 @@
 ## This example, Deploys nginx with an internal service, that allows reading the Cloud provider and Region json. This is designed to work with the modified Pacman application.
 1. Add the subscription to your Red Hat Advanced Cluster Management for Kubernetes HUB
 ```
-clone https://github.com/stolostron/application-samples.git
+clone https://github.com/mbaldessari/application-samples.git
 oc apply -k application-samples/subscriptoins/cloud-provider
 ```
 ### results

--- a/cloud-provider/README.md
+++ b/cloud-provider/README.md
@@ -3,7 +3,7 @@
 ## This example, Deploys nginx with an internal service, that allows reading the Cloud provider and Region json. This is designed to work with the modified Pacman application.
 1. Add the subscription to your Red Hat Advanced Cluster Management for Kubernetes HUB
 ```
-clone https://github.com/open-cluster-management/application-samples.git
+clone https://github.com/stolostron/application-samples.git
 oc apply -k application-samples/subscriptoins/cloud-provider
 ```
 ### results

--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -23,7 +23,7 @@ Using the application console, you can easily create an Application to run this 
   * **Name:** `helloworld`
   * **Namespace:** `helloworld`
   * **Repository types:** `Git`
-  * **URL:** `https://github.com/open-cluster-management/application-samples.git`
+  * **URL:** `https://github.com/stolostron/application-samples.git`
   * **Branch:** `main`
   * **Path:** `helloworld`
   * Select `Deploy application resources only on clusters matching specified labels`

--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -23,7 +23,7 @@ Using the application console, you can easily create an Application to run this 
   * **Name:** `helloworld`
   * **Namespace:** `helloworld`
   * **Repository types:** `Git`
-  * **URL:** `https://github.com/stolostron/application-samples.git`
+  * **URL:** `https://github.com/mbaldessari/application-samples.git`
   * **Branch:** `main`
   * **Path:** `helloworld`
   * Select `Deploy application resources only on clusters matching specified labels`

--- a/mortgage/README.md
+++ b/mortgage/README.md
@@ -23,7 +23,7 @@ Using the application console, you can easily create an Application to run this 
   * **Name:** `mortgage`
   * **Namespace:** `mortgage`
   * **Repository types:** `Git`
-  * **URL:** `https://github.com/open-cluster-management/application-samples.git`
+  * **URL:** `https://github.com/stolostron/application-samples.git`
   * **Branch:** `main`
   * **Path:** `mortgage`
   * Select `Deploy application resources only on clusters matching specified labels`

--- a/mortgage/README.md
+++ b/mortgage/README.md
@@ -23,7 +23,7 @@ Using the application console, you can easily create an Application to run this 
   * **Name:** `mortgage`
   * **Namespace:** `mortgage`
   * **Repository types:** `Git`
-  * **URL:** `https://github.com/stolostron/application-samples.git`
+  * **URL:** `https://github.com/mbaldessari/application-samples.git`
   * **Branch:** `main`
   * **Path:** `mortgage`
   * Select `Deploy application resources only on clusters matching specified labels`

--- a/s390x-sleep/README.md
+++ b/s390x-sleep/README.md
@@ -28,7 +28,7 @@ Using the application console, you can easily create an Application to run this 
   * **Name:** `s390x-sleep`
   * **Namespace:** `s390x-sleep`
   * **Repository types:** `Git`
-  * **URL:** `https://github.com/stolostron/application-samples.git`
+  * **URL:** `https://github.com/mbaldessari/application-samples.git`
   * **Branch:** `main`
   * **Path:** `s390x-sleep`
   * Select `Deploy application resources only on clusters matching specified labels`

--- a/s390x-sleep/README.md
+++ b/s390x-sleep/README.md
@@ -28,7 +28,7 @@ Using the application console, you can easily create an Application to run this 
   * **Name:** `s390x-sleep`
   * **Namespace:** `s390x-sleep`
   * **Repository types:** `Git`
-  * **URL:** `https://github.com/open-cluster-management/application-samples.git`
+  * **URL:** `https://github.com/stolostron/application-samples.git`
   * **Branch:** `main`
   * **Path:** `s390x-sleep`
   * Select `Deploy application resources only on clusters matching specified labels`

--- a/secret-management/README.md
+++ b/secret-management/README.md
@@ -11,7 +11,7 @@ Red Hat ACM Namespace channel has a special secret feature.  This takes a secret
 This defines the Application object that groups all the subscriptions you want to use to distribute your secrets together.
 
 ### channel.yaml
-This defines a namespace `my-secrets-ch` where you are exptect to create the secrets you want to distrbute.  The channel name will be `my-secret`, so the channel path you define in the subscription is `NAMESPACE/SECRET` or `my-secrets-ch/my-secret`.
+This defines a namespace `my-secrets-ch` where you are expected to create the secrets you want to distribute.  The channel name will be `my-secret`, so the channel path you define in the subscription is `NAMESPACE/SECRET` or `my-secrets-ch/my-secret`.
 
 ### placement.yaml
 This defines the target clusters where you want your secret(s) delivered. You can have one placement rule or many.  Placement rules can be shared between subscriptions.  You can modify the labelSelector or the MatchExpression to define the target clusters.
@@ -41,4 +41,4 @@ metadata:
 ```
 
 ### Note Important
-Your secrets need the `aps.open-cluster-management.io/deployables` annotation to be delivered.  To filter out which secrets to deliver, use a unique key and value pair for the `packageFilter` on the Subscription.
+Your secrets need the `apps.open-cluster-management.io/deployables` annotation to be delivered.  To filter out which secrets to deliver, use a unique key and value pair for the `packageFilter` on the Subscription.

--- a/secret-management/kustomization.yaml
+++ b/secret-management/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 - channel.yaml
 - placement.yaml
 - subscription.yaml
-- secrets.yaml
+- secret.yaml

--- a/secret-management/secret.yaml
+++ b/secret-management/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hive43-aws-test-install-config
+  namespace: my-secrets-ch
   annotations: 
     apps.open-cluster-management.io/deployables: "secret"
     secretname: my-secret

--- a/subscriptions/channel/channel.yaml
+++ b/subscriptions/channel/channel.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: application-samples
 spec:
   type: GitHub
-  pathname: https://github.com/open-cluster-management/application-samples.git
+  pathname: https://github.com/stolostron/application-samples.git

--- a/subscriptions/channel/channel.yaml
+++ b/subscriptions/channel/channel.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: application-samples
 spec:
   type: GitHub
-  pathname: https://github.com/stolostron/application-samples.git
+  pathname: https://github.com/mbaldessari/application-samples.git

--- a/subscriptions/helloworld/channel.yaml
+++ b/subscriptions/helloworld/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: helloworld-ch
 spec:
   type: GitHub
-  pathname: https://github.com/open-cluster-management/application-samples.git
+  pathname: https://github.com/stolostron/application-samples.git

--- a/subscriptions/helloworld/channel.yaml
+++ b/subscriptions/helloworld/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: helloworld-ch
 spec:
   type: GitHub
-  pathname: https://github.com/stolostron/application-samples.git
+  pathname: https://github.com/mbaldessari/application-samples.git

--- a/subscriptions/istio-multicluster-servicemesh/bookinfo/channel.yaml
+++ b/subscriptions/istio-multicluster-servicemesh/bookinfo/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: istio-apps
 spec:
   type: GitHub
-  pathname: https://github.com/open-cluster-management/application-samples.git
+  pathname: https://github.com/stolostron/application-samples.git

--- a/subscriptions/istio-multicluster-servicemesh/bookinfo/channel.yaml
+++ b/subscriptions/istio-multicluster-servicemesh/bookinfo/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: istio-apps
 spec:
   type: GitHub
-  pathname: https://github.com/stolostron/application-samples.git
+  pathname: https://github.com/mbaldessari/application-samples.git

--- a/subscriptions/istio-multicluster-servicemesh/istio-multicluster/channel.yaml
+++ b/subscriptions/istio-multicluster-servicemesh/istio-multicluster/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: istio-system
 spec:
   type: GitHub
-  pathname: https://github.com/stolostron/application-samples.git
+  pathname: https://github.com/mbaldessari/application-samples.git

--- a/subscriptions/istio-multicluster-servicemesh/istio-multicluster/channel.yaml
+++ b/subscriptions/istio-multicluster-servicemesh/istio-multicluster/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: istio-system
 spec:
   type: GitHub
-  pathname: https://github.com/open-cluster-management/application-samples.git
+  pathname: https://github.com/stolostron/application-samples.git

--- a/subscriptions/mortgage/channel.yaml
+++ b/subscriptions/mortgage/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: mortgage-ch
 spec:
   type: GitHub
-  pathname: https://github.com/open-cluster-management/application-samples.git
+  pathname: https://github.com/stolostron/application-samples.git

--- a/subscriptions/mortgage/channel.yaml
+++ b/subscriptions/mortgage/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: mortgage-ch
 spec:
   type: GitHub
-  pathname: https://github.com/stolostron/application-samples.git
+  pathname: https://github.com/mbaldessari/application-samples.git

--- a/subscriptions/s390x-sleep/channel.yaml
+++ b/subscriptions/s390x-sleep/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: s390x-sleep-ch
 spec:
   type: GitHub
-  pathname: https://github.com/stolostron/application-samples.git
+  pathname: https://github.com/mbaldessari/application-samples.git

--- a/subscriptions/s390x-sleep/channel.yaml
+++ b/subscriptions/s390x-sleep/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: s390x-sleep-ch
 spec:
   type: GitHub
-  pathname: https://github.com/open-cluster-management/application-samples.git
+  pathname: https://github.com/stolostron/application-samples.git


### PR DESCRIPTION
- Rename all open-cluster-management github urls to stolostron
- test
- Fix typos and make sure the secret is in the my-secrets-ch namespace
