### PR TITLE
Fix typos and secret namespace

### DIFF
--- a/secret-management/README.md
+++ b/secret-management/README.md
@@ -11,7 +11,7 @@ Red Hat ACM Namespace channel has a special secret feature.  This takes a secret
 This defines the Application object that groups all the subscriptions you want to use to distribute your secrets together.
 
 ### channel.yaml
-This defines a namespace `my-secrets-ch` where you are exptect to create the secrets you want to distrbute.  The channel name will be `my-secret`, so the channel path you define in the subscription is `NAMESPACE/SECRET` or `my-secrets-ch/my-secret`.
+This defines a namespace `my-secrets-ch` where you are expected to create the secrets you want to distribute.  The channel name will be `my-secret`, so the channel path you define in the subscription is `NAMESPACE/SECRET` or `my-secrets-ch/my-secret`.
 
 ### placement.yaml
 This defines the target clusters where you want your secret(s) delivered. You can have one placement rule or many.  Placement rules can be shared between subscriptions.  You can modify the labelSelector or the MatchExpression to define the target clusters.
@@ -41,4 +41,4 @@ metadata:
 ```
 
 ### Note Important
-Your secrets need the `aps.open-cluster-management.io/deployables` annotation to be delivered.  To filter out which secrets to deliver, use a unique key and value pair for the `packageFilter` on the Subscription.
+Your secrets need the `apps.open-cluster-management.io/deployables` annotation to be delivered.  To filter out which secrets to deliver, use a unique key and value pair for the `packageFilter` on the Subscription.

--- a/secret-management/kustomization.yaml
+++ b/secret-management/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 - channel.yaml
 - placement.yaml
 - subscription.yaml
-- secrets.yaml
+- secret.yaml

--- a/secret-management/secret.yaml
+++ b/secret-management/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hive43-aws-test-install-config
+  namespace: my-secrets-ch
   annotations: 
     apps.open-cluster-management.io/deployables: "secret"
     secretname: my-secret


### PR DESCRIPTION
Without this change the secret never gets propagated to the other
clusters. While we're at it, let's fix a couple of typos in the README
and also s/secrets/secret/ so kustomize won't error out on this example.

With this change I was able to see the secret propagate to the other
clusters. Without it the secret gets created in the default namespace
and never gets picked up by the subscription.
